### PR TITLE
Update .gitignore to avoid sensitive information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ package.xml
 #recommended to manage this outside git
 
 installedPackages/*
+certs/*
+connectedApps/*
+samlssoconfigs/*
+namedCredentials/*
 
 #if you are not customizing a managed package, you can keep your repository clean by ignoring 
 #all files for that package. For example, to ignore all files of the "Copado" managed package


### PR DESCRIPTION
According to best practices we should exclude metadata types which can hold sensitive information.